### PR TITLE
fix: Relates to #9. Reuse calculation of average block time

### DIFF
--- a/packages/backend/src/Chain.ts
+++ b/packages/backend/src/Chain.ts
@@ -2,7 +2,7 @@ import * as EventEmitter from 'events';
 import Node from './Node';
 import Feed from './Feed';
 import FeedSet from './FeedSet';
-import { Maybe, Types, FeedMessage } from '@dotstats/common';
+import { Maybe, Types, FeedMessage, blockAverage } from '@dotstats/common';
 
 const BLOCK_TIME_HISTORY = 10;
 
@@ -112,17 +112,7 @@ export default class Chain {
   private updateAverageBlockTime(height: Types.BlockNumber, now: Types.Timestamp) {
     this.blockTimes[height % BLOCK_TIME_HISTORY] = now - this.blockTimestamp;
 
-    let sum = 0;
-    let count = 0;
-
-    for (const time of this.blockTimes) {
-      if (time) {
-        sum += time;
-        count += 1;
-      }
-    }
-
     // We are guaranteed that count > 0
-    this.averageBlockTime = (sum / count) as Types.Milliseconds;
+    this.averageBlockTime = blockAverage(this.blockTimes);
   }
 }

--- a/packages/backend/src/Node.ts
+++ b/packages/backend/src/Node.ts
@@ -1,6 +1,7 @@
 import * as WebSocket from 'ws';
 import * as EventEmitter from 'events';
-import { noop, timestamp, Maybe, Types, idGenerator } from '@dotstats/common';
+
+import { noop, timestamp, Maybe, Types, idGenerator, blockAverage } from '@dotstats/common';
 import { parseMessage, getBestBlock, Message, BestBlock, SystemInterval } from './message';
 import { locate, Location } from './location';
 
@@ -176,22 +177,8 @@ export default class Node {
     return location ? [location.lat, location.lon, location.city] : null;
   }
 
-  public get average(): number {
-    let accounted = 0;
-    let sum = 0;
-
-    for (const time of this.blockTimes) {
-      if (time) {
-        accounted += 1;
-        sum += time;
-      }
-    }
-
-    if (accounted === 0) {
-      return 0;
-    }
-
-    return sum / accounted;
+  public get average(): Types.Milliseconds {
+    return blockAverage(this.blockTimes);
   }
 
   public get localBlockAt(): Types.Milliseconds {

--- a/packages/common/src/block.ts
+++ b/packages/common/src/block.ts
@@ -1,6 +1,6 @@
-import { Types } from '@dotstats/common';
+import { Milliseconds } from './types';
 
-export function blockAverage(blockTimes: Array<number>): Types.Milliseconds {
+export function blockAverage(blockTimes: Array<number>): Milliseconds {
   let count = 0;
   let sum = 0;
 
@@ -12,8 +12,8 @@ export function blockAverage(blockTimes: Array<number>): Types.Milliseconds {
   }
 
   if (count === 0) {
-    return 0 as Types.Milliseconds;
+    return 0 as Milliseconds;
   }
 
-  return (sum / count) as Types.Milliseconds;
+  return (sum / count) as Milliseconds;
 }

--- a/packages/common/src/block.ts
+++ b/packages/common/src/block.ts
@@ -1,0 +1,19 @@
+import { Maybe, Types } from '@dotstats/common';
+
+export function blockAverage(blockTimes: Array<number>): Maybe<Types.Milliseconds> {
+  let count = 0;
+  let sum = 0;
+
+  for (const time of blockTimes) {
+    if (time) {
+      count += 1;
+      sum += time;
+    }
+  }
+
+  if (count === 0) {
+    return 0 as Types.Milliseconds;
+  }
+
+  return (sum / count) as Types.Milliseconds;
+}

--- a/packages/common/src/block.ts
+++ b/packages/common/src/block.ts
@@ -1,4 +1,4 @@
-import { Maybe, Types } from '@dotstats/common';
+import { Types } from '@dotstats/common';
 
 export function blockAverage(blockTimes: Array<number>): Types.Milliseconds {
   let count = 0;

--- a/packages/common/src/block.ts
+++ b/packages/common/src/block.ts
@@ -1,6 +1,6 @@
 import { Maybe, Types } from '@dotstats/common';
 
-export function blockAverage(blockTimes: Array<number>): Maybe<Types.Milliseconds> {
+export function blockAverage(blockTimes: Array<number>): Types.Milliseconds {
   let count = 0;
   let sum = 0;
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -1,5 +1,6 @@
 export * from './helpers';
 export * from './id';
+export * from './block';
 
 import * as Types from './types';
 import * as FeedMessage from './feed';


### PR DESCRIPTION
* **Issues**
  * Unable to import `blockAverage` into Chain.ts or Node.ts due to Issue #21.
  * TypeScript says `[ts] Module '"/Users/Me/code/blockchain/clones/paritytech/dotstats/packages/common/build/index"' has no exported member 'blockAverage'.`